### PR TITLE
Fix the leak issue in the list

### DIFF
--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchFragment.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchFragment.java
@@ -103,7 +103,9 @@ public final class SearchFragment extends BindingBaseFragment<SearchFragmentComp
         super.onViewCreated(view, savedInstanceState);
         resultsRecyclerView = (RecyclerView) view
                 .findViewById(R.id.recyclerView_searchResults);
-        get(resultsRecyclerView).setLayoutManager(new LinearLayoutManager(getActivity()));
+        final LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
+        layoutManager.setRecycleChildrenOnDetach(true);
+        get(resultsRecyclerView).setLayoutManager(layoutManager);
         noResultsTextView = (TextView) view.findViewById(R.id.textView_searchNoResults);
     }
 


### PR DESCRIPTION
Should fix #18 

This solution is a tradeoff between simplicity and having proper hooks to lifecycle. 

The view holders will unbind when the fragment is destroyed but will remain binded when the fragment is paused. 
