### PR TITLE
[CHORE] Make module provides methods static

### DIFF
--- a/app/src/debug/java/com/futurice/freesound/logging/LoggingModule.java
+++ b/app/src/debug/java/com/futurice/freesound/logging/LoggingModule.java
@@ -27,7 +27,7 @@ public class LoggingModule {
 
     @Provides
     @Singleton
-    Timber.Tree provideLoggingTree() {
+    static Timber.Tree provideLoggingTree() {
         return new Timber.DebugTree();
     }
 }

--- a/app/src/main/java/com/futurice/freesound/app/module/ApiModule.java
+++ b/app/src/main/java/com/futurice/freesound/app/module/ApiModule.java
@@ -55,10 +55,10 @@ public class ApiModule {
 
     @Provides
     @Singleton
-    FreeSoundApi provideFreeSoundApi(Endpoint endpoint,
-                                     Client client,
-                                     Converter converter,
-                                     RequestInterceptor requestInterceptor) {
+    static FreeSoundApi provideFreeSoundApi(Endpoint endpoint,
+                                            Client client,
+                                            Converter converter,
+                                            RequestInterceptor requestInterceptor) {
         return new RestAdapter.Builder()
                 .setEndpoint(endpoint)
                 .setClient(client)
@@ -73,32 +73,32 @@ public class ApiModule {
 
     @Provides
     @Singleton
-    Endpoint provideEndpoint(@Named(URL_CONFIG) String url) {
+    static Endpoint provideEndpoint(@Named(URL_CONFIG) String url) {
         return Endpoints.newFixedEndpoint(url);
     }
 
     @Provides
     @Singleton
-    OkHttpClient provideApiOkHttpClient(@AppInterceptors List<Interceptor> appInterceptor,
-                                        @NetworkInterceptors List<Interceptor> networkInterceptor) {
+    static OkHttpClient provideApiOkHttpClient(@AppInterceptors List<Interceptor> appInterceptor,
+                                               @NetworkInterceptors List<Interceptor> networkInterceptor) {
         return createOkHttpClient(appInterceptor, networkInterceptor);
     }
 
     @Provides
     @Singleton
-    Client provideClient(OkHttpClient okHttpClient) {
+    static Client provideClient(OkHttpClient okHttpClient) {
         return new OkClient(okHttpClient);
     }
 
     @Provides
     @Singleton
-    Converter provideConverter(Gson gson) {
+    static Converter provideConverter(Gson gson) {
         return new GsonConverter(gson);
     }
 
     @Provides
     @Singleton
-    Gson provideGson() {
+    static Gson provideGson() {
         return new GsonBuilder()
                 .registerTypeAdapter(GeoLocation.class, new GeoLocationDeserializer())
                 .registerTypeAdapterFactory(new AutoValueGsonTypeAdapterFactory())
@@ -107,7 +107,7 @@ public class ApiModule {
 
     @Provides
     @Singleton
-    RequestInterceptor provideRequestInterceptor(@Named(API_TOKEN_CONFIG) String apiToken) {
+    static RequestInterceptor provideRequestInterceptor(@Named(API_TOKEN_CONFIG) String apiToken) {
         return new FreeSoundApiInterceptor(apiToken);
     }
 

--- a/app/src/main/java/com/futurice/freesound/app/module/ConfigModule.java
+++ b/app/src/main/java/com/futurice/freesound/app/module/ConfigModule.java
@@ -30,14 +30,14 @@ public class ConfigModule {
     @Provides
     @Singleton
     @Named(ApiModule.URL_CONFIG)
-    String provideApiModuleUrlConfig() {
+    static String provideApiModuleUrlConfig() {
         return BuildConfig.FREESOUND_API_URL;
     }
 
     @Provides
     @Singleton
     @Named(ApiModule.API_TOKEN_CONFIG)
-    String provideApiModuleApiTokenConfig() {
+    static String provideApiModuleApiTokenConfig() {
         return BuildConfig.FREESOUND_API_KEY;
     }
 

--- a/app/src/main/java/com/futurice/freesound/app/module/ImagesModule.java
+++ b/app/src/main/java/com/futurice/freesound/app/module/ImagesModule.java
@@ -31,7 +31,7 @@ public class ImagesModule {
 
     @Provides
     @Singleton
-    Picasso providePicasso(@ForApplication Context context) {
+    static Picasso providePicasso(@ForApplication Context context) {
         return Picasso.with(context);
     }
 

--- a/app/src/main/java/com/futurice/freesound/app/module/InstrumentationModule.java
+++ b/app/src/main/java/com/futurice/freesound/app/module/InstrumentationModule.java
@@ -34,7 +34,7 @@ public class InstrumentationModule {
     @Provides
     @Singleton
     @ApiModule.NetworkInterceptors
-    List<Interceptor> provideNetworkInterceptors() {
+    static List<Interceptor> provideNetworkInterceptors() {
         ArrayList<Interceptor> networkInterceptors = new ArrayList<>();
         networkInterceptors.add(new StethoInterceptor());
         return networkInterceptors;
@@ -42,7 +42,8 @@ public class InstrumentationModule {
 
     @Provides
     @Singleton
-    @ApiModule.AppInterceptors List<Interceptor> provideAppInterceptors() {
+    @ApiModule.AppInterceptors
+    static List<Interceptor> provideAppInterceptors() {
         return Collections.emptyList();
     }
 }

--- a/app/src/main/java/com/futurice/freesound/feature/analytics/AnalyticsModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/analytics/AnalyticsModule.java
@@ -26,7 +26,7 @@ public class AnalyticsModule {
 
     @Provides
     @Singleton
-    Analytics provideAnalytics(FirebaseAnalytics firebaseAnalytics) {
+    static Analytics provideAnalytics(FirebaseAnalytics firebaseAnalytics) {
         return firebaseAnalytics;
     }
 }

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeActivityModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeActivityModule.java
@@ -28,7 +28,7 @@ class HomeActivityModule {
 
     @Provides
     @ActivityScope
-    HomeViewModel provideHomeViewModel(Navigator navigator) {
+    static HomeViewModel provideHomeViewModel(Navigator navigator) {
         return new HomeViewModel(navigator);
     }
 

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchActivityModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchActivityModule.java
@@ -32,21 +32,21 @@ class SearchActivityModule {
 
     @Provides
     @ActivityScope
-    SearchViewModel provideSearchViewModel(SearchDataModel searchDataModel,
-                                           Navigator navigator,
-                                           Analytics analytics) {
+    static SearchViewModel provideSearchViewModel(SearchDataModel searchDataModel,
+                                                  Navigator navigator,
+                                                  Analytics analytics) {
         return new SearchViewModel(searchDataModel, navigator, analytics);
     }
 
     @Provides
     @ActivityScope
-    SearchDataModel provideSearchDataModel(FreeSoundSearchService freeSoundSearchService) {
+    static SearchDataModel provideSearchDataModel(FreeSoundSearchService freeSoundSearchService) {
         return new DefaultSearchDataModel(freeSoundSearchService);
     }
 
     @Provides
     @ActivityScope
-    FreeSoundSearchService provideFreeSoundsSearchService(FreeSoundApi freeSoundApi) {
+    static FreeSoundSearchService provideFreeSoundsSearchService(FreeSoundApi freeSoundApi) {
         return new DefaultFreeSoundSearchService(freeSoundApi);
     }
 }

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchFragmentModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchFragmentModule.java
@@ -32,21 +32,22 @@ public class SearchFragmentModule {
 
     @Provides
     @FragmentScope
-    SoundItemAdapter provideSoundItemAdapter(DefaultAdapterInteractor<Sound> adapterInteractor,
-                                             Picasso picasso,
-                                             SoundItemViewModel_Factory viewModelFactory) {
+    static SoundItemAdapter provideSoundItemAdapter(
+            DefaultAdapterInteractor<Sound> adapterInteractor,
+            Picasso picasso,
+            SoundItemViewModel_Factory viewModelFactory) {
         return new SoundItemAdapter(adapterInteractor, picasso, viewModelFactory);
     }
 
     @Provides
     @FragmentScope
-    SoundItemViewModel_Factory provideSoundItemViewModelFactory(Navigator navigator) {
+    static SoundItemViewModel_Factory provideSoundItemViewModelFactory(Navigator navigator) {
         return new SoundItemViewModel_Factory(navigator);
     }
 
     @Provides
     @FragmentScope
-    DefaultAdapterInteractor<Sound> provideAdapterInteractor() {
+    static DefaultAdapterInteractor<Sound> provideAdapterInteractor() {
         return new AdapterInteractor<>();
     }
 }

--- a/app/src/main/java/com/futurice/freesound/inject/activity/BaseActivityModule.java
+++ b/app/src/main/java/com/futurice/freesound/inject/activity/BaseActivityModule.java
@@ -49,7 +49,7 @@ public class BaseActivityModule {
 
     @Provides
     @ActivityScope
-    Navigator provideNavigator(android.app.Activity activity) {
+    static Navigator provideNavigator(android.app.Activity activity) {
         return new DefaultNavigator(activity);
     }
 

--- a/app/src/release/java/com/futurice/freesound/logging/LoggingModule.java
+++ b/app/src/release/java/com/futurice/freesound/logging/LoggingModule.java
@@ -27,13 +27,13 @@ public class LoggingModule {
 
     @Provides
     @Singleton
-    Timber.Tree provideLoggingTree(FirebaseErrorReporter firebaseErrorReporter) {
+    static Timber.Tree provideLoggingTree(FirebaseErrorReporter firebaseErrorReporter) {
         return new FirebaseReleaseTree(firebaseErrorReporter);
     }
 
     @Provides
     @Singleton
-    FirebaseErrorReporter provideFirebaseErrorReporter() {
+    static FirebaseErrorReporter provideFirebaseErrorReporter() {
         return new FirebaseErrorReporter();
     }
 

--- a/app/src/test/java/com/futurice/freesound/utils/CollectionUtilsTest.java
+++ b/app/src/test/java/com/futurice/freesound/utils/CollectionUtilsTest.java
@@ -67,6 +67,7 @@ public class CollectionUtilsTest {
         assertThat(areEqual).isFalse();
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void areEqual_returnsFalse_whenOneCollectionIsNull() {
         Collection collection1 = createRangeCollection(0, 5);
@@ -77,6 +78,7 @@ public class CollectionUtilsTest {
         assertThat(areEqual).isFalse();
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void areEqual_returnsFalse_whenBothCollectionsAreNull() {
         Collection collection1 = null;

--- a/app/src/testDebug/java/com/futurice/freesound/logging/LoggingModuleTest.java
+++ b/app/src/testDebug/java/com/futurice/freesound/logging/LoggingModuleTest.java
@@ -26,7 +26,7 @@ public class LoggingModuleTest {
 
     @Test
     public void provideLoggingTree_isDebugTree_inDebugVariant() {
-        assertThat(new LoggingModule().provideLoggingTree())
+        assertThat(LoggingModule.provideLoggingTree())
                 .isInstanceOf(Timber.DebugTree.class);
     }
 

--- a/app/src/testRelease/java/com/futurice/freesound/logging/LoggingModuleTest.java
+++ b/app/src/testRelease/java/com/futurice/freesound/logging/LoggingModuleTest.java
@@ -35,7 +35,7 @@ public class LoggingModuleTest {
 
     @Test
     public void provideLoggingTree_isFirebaseReleaseTree_inReleaseVariant() {
-        assertThat(new LoggingModule().provideLoggingTree(mFirebaseErrorReporter))
+        assertThat(LoggingModule.provideLoggingTree(mFirebaseErrorReporter))
                 .isInstanceOf(FirebaseReleaseTree.class);
     }
 


### PR DESCRIPTION
According to the Dagger 2 docs, there is a performance benefit when a module can be made entirely static:

> Any module with an accessible default constructor can be elided as the builder will construct an  instance automatically if none is set. And for any module whose @Provides methods are all static, the implementation doesn’t need an instance at all. If all dependencies can be constructed without the user creating a dependency instance, then the generated implementation will also have a create() method that can be used to get a new instance without having to deal with the builder.