### PR TITLE
Remove module instantiation

### DIFF
--- a/app/src/main/java/com/futurice/freesound/app/FreesoundApplication.java
+++ b/app/src/main/java/com/futurice/freesound/app/FreesoundApplication.java
@@ -17,8 +17,6 @@
 package com.futurice.freesound.app;
 
 import com.facebook.stetho.Stetho;
-import com.futurice.freesound.app.module.ApiModule;
-import com.futurice.freesound.app.module.ImagesModule;
 import com.futurice.freesound.core.BaseApplication;
 import com.futurice.freesound.inject.app.BaseApplicationModule;
 
@@ -54,8 +52,6 @@ public class FreesoundApplication extends BaseApplication<FreesoundApplicationCo
         return DaggerFreesoundApplicationComponent.builder()
                                                   .baseApplicationModule(
                                                           new BaseApplicationModule(this))
-                                                  .apiModule(new ApiModule())
-                                                  .imagesModule(new ImagesModule())
                                                   .build();
     }
 

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeActivity.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeActivity.java
@@ -106,7 +106,6 @@ public class HomeActivity extends BindingBaseActivity<HomeActivityComponent> {
                                                   ((FreesoundApplication) getApplication())
                                                           .component())
                                           .baseActivityModule(new BaseActivityModule(this))
-                                          .homeActivityModule(new HomeActivityModule())
                                           .build();
     }
 

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchActivity.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchActivity.java
@@ -151,7 +151,6 @@ public class SearchActivity extends BindingBaseActivity<SearchActivityComponent>
                                                     ((FreesoundApplication) this
                                                             .getApplication()).component())
                                             .baseActivityModule(new BaseActivityModule(this))
-                                            .searchActivityModule(new SearchActivityModule())
                                             .build();
     }
 

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchFragment.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchFragment.java
@@ -124,7 +124,6 @@ public final class SearchFragment extends BindingBaseFragment<SearchFragmentComp
                                             .searchActivityComponent(
                                                     ((SearchActivity) getActivity()).component())
                                             .baseFragmentModule(new BaseFragmentModule(this))
-                                            .searchFragmentModule(new SearchFragmentModule())
                                             .build();
     }
 

--- a/app/src/test/java/com/futurice/freesound/feature/search/DefaultSearchDataModelTest.java
+++ b/app/src/test/java/com/futurice/freesound/feature/search/DefaultSearchDataModelTest.java
@@ -20,6 +20,7 @@ import com.futurice.freesound.network.api.FreeSoundSearchService;
 import com.futurice.freesound.network.api.model.Sound;
 import com.futurice.freesound.network.api.model.SoundSearchResult;
 import com.futurice.freesound.test.data.TestData;
+import com.futurice.freesound.test.rx.IgnoringObserver;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -33,7 +34,6 @@ import java.util.List;
 import polanski.option.Option;
 import polanski.option.Unit;
 import rx.Observable;
-import rx.observers.TestObserver;
 import rx.observers.TestSubscriber;
 
 import static com.futurice.freesound.test.utils.TestSubscriberUtils.testSubscribe;
@@ -125,7 +125,7 @@ public class DefaultSearchDataModelTest {
         TestSubscriber<Option<List<Sound>>> ts = testSubscribe(
                 defaultSearchDataModel.getSearchResults());
 
-        defaultSearchDataModel.querySearch("dummy").subscribe(new TestObserver<>());
+        defaultSearchDataModel.querySearch("dummy").subscribe(IgnoringObserver.create());
 
         assertThat(ts).hasNoErrors();
     }
@@ -206,7 +206,7 @@ public class DefaultSearchDataModelTest {
     private class Act {
 
         void querySearch(String query) {
-            defaultSearchDataModel.querySearch(query).subscribe(new TestObserver<>());
+            defaultSearchDataModel.querySearch(query).subscribe();
         }
     }
 

--- a/app/src/test/java/com/futurice/freesound/network/api/DefaultFreeSoundSearchServiceTest.java
+++ b/app/src/test/java/com/futurice/freesound/network/api/DefaultFreeSoundSearchServiceTest.java
@@ -77,6 +77,7 @@ public class DefaultFreeSoundSearchServiceTest {
 
         testSubscribe(defaultFreeSoundSearchService.search(QUERY));
 
+        //noinspection deprecation
         verify(freeSoundApi).search(eq(QUERY), isNull(String.class), eq(SoundFields.BASE));
     }
 

--- a/app/src/test/java/com/futurice/freesound/test/rx/IgnoringObserver.java
+++ b/app/src/test/java/com/futurice/freesound/test/rx/IgnoringObserver.java
@@ -1,0 +1,31 @@
+package com.futurice.freesound.test.rx;
+
+import android.support.annotation.NonNull;
+
+import rx.Observer;
+
+/**
+ * An {@link Observer} which swallows all events without side effects.
+ */
+public class IgnoringObserver<T> implements Observer<T> {
+
+    @NonNull
+    public static <T> Observer<T> create() {
+        return new IgnoringObserver<>();
+    }
+
+    @Override
+    public void onCompleted() {
+
+    }
+
+    @Override
+    public void onError(final Throwable e) {
+
+    }
+
+    @Override
+    public void onNext(final T t) {
+
+    }
+}

--- a/app/src/test/java/com/futurice/freesound/test/rx/IgnoringObserver.java
+++ b/app/src/test/java/com/futurice/freesound/test/rx/IgnoringObserver.java
@@ -23,7 +23,7 @@ import rx.Observer;
 /**
  * An {@link Observer} which swallows all events without side effects.
  */
-public class IgnoringObserver<T> implements Observer<T> {
+public final class IgnoringObserver<T> implements Observer<T> {
 
     @NonNull
     public static <T> Observer<T> create() {

--- a/app/src/test/java/com/futurice/freesound/test/rx/IgnoringObserver.java
+++ b/app/src/test/java/com/futurice/freesound/test/rx/IgnoringObserver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Futurice GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.futurice.freesound.test.rx;
 
 import android.support.annotation.NonNull;


### PR DESCRIPTION
There were deprecated warnings for the module instantiation of static modules; this PR cleans up that and some other deprecation warnings.