### PR TITLE
Install the Stetho interceptor only in the debug build. 

### DIFF
--- a/app/src/debug/java/com/futurice/freesound/app/module/InstrumentationModule.java
+++ b/app/src/debug/java/com/futurice/freesound/app/module/InstrumentationModule.java
@@ -17,13 +17,11 @@
 package com.futurice.freesound.app.module;
 
 import com.facebook.stetho.okhttp3.StethoInterceptor;
-import com.futurice.freesound.network.api.FreeSoundApiInterceptor;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -32,20 +30,17 @@ import okhttp3.Interceptor;
 import okhttp3.logging.HttpLoggingInterceptor;
 import timber.log.Timber;
 
-import static com.futurice.freesound.app.module.ApiModule.API_TOKEN_CONFIG;
-
 @Module
 public final class InstrumentationModule {
 
     @Provides
     @Singleton
     @ApiModule.NetworkInterceptors
-    static List<Interceptor> provideNetworkInterceptors(FreeSoundApiInterceptor apiInterceptor,
-                                                        HttpLoggingInterceptor loggingInterceptor) {
-        List<Interceptor> networkInterceptors = new ArrayList<>(1);
-        networkInterceptors.add(new StethoInterceptor());
-        networkInterceptors.add(apiInterceptor);
+    static List<Interceptor> provideNetworkInterceptors(HttpLoggingInterceptor loggingInterceptor,
+                                                        StethoInterceptor stethoInterceptor) {
+        List<Interceptor> networkInterceptors = new ArrayList<>(2);
         networkInterceptors.add(loggingInterceptor);
+        networkInterceptors.add(stethoInterceptor);
         return networkInterceptors;
     }
 
@@ -58,17 +53,17 @@ public final class InstrumentationModule {
 
     @Provides
     @Singleton
-    static FreeSoundApiInterceptor provideApiInterceptor(@Named(API_TOKEN_CONFIG) String apiToken) {
-        return new FreeSoundApiInterceptor(apiToken);
-    }
-
-    @Provides
-    @Singleton
     static HttpLoggingInterceptor provideLoggingInterceptor() {
         HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor(
                 message -> Timber.tag("OkHttp").d(message));
         // TODO Headers only: Bug in HttpLoggingInterceptor, uses not public api
         interceptor.setLevel(HttpLoggingInterceptor.Level.HEADERS);
         return interceptor;
+    }
+
+    @Provides
+    @Singleton
+    static StethoInterceptor provideStethoInterceptor() {
+        return new StethoInterceptor();
     }
 }

--- a/app/src/main/java/com/futurice/freesound/app/module/ApiModule.java
+++ b/app/src/main/java/com/futurice/freesound/app/module/ApiModule.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import com.futurice.freesound.network.api.FreeSoundApi;
+import com.futurice.freesound.network.api.FreeSoundApiInterceptor;
 import com.futurice.freesound.network.api.model.GeoLocation;
 import com.futurice.freesound.network.api.model.mapping.GeoLocationDeserializer;
 import com.jakewharton.retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
@@ -78,17 +79,26 @@ public final class ApiModule {
     @Singleton
     @ForFreeSoundApi
     static OkHttpClient provideApiOkHttpClient(@AppInterceptors List<Interceptor> appInterceptor,
-                                               @NetworkInterceptors List<Interceptor> networkInterceptor) {
-        return createOkHttpClient(appInterceptor, networkInterceptor);
+                                               @NetworkInterceptors List<Interceptor> networkInterceptor,
+                                               FreeSoundApiInterceptor apiInterceptor) {
+        return createOkHttpClient(appInterceptor, networkInterceptor, apiInterceptor);
     }
 
     private static OkHttpClient createOkHttpClient(List<Interceptor> appInterceptors,
-                                                   List<Interceptor> networkInterceptors) {
+                                                   List<Interceptor> networkInterceptors,
+                                                   FreeSoundApiInterceptor freeSoundApiInterceptor) {
         Builder okBuilder = new Builder();
         okBuilder.interceptors().addAll(appInterceptors);
         okBuilder.networkInterceptors().addAll(networkInterceptors);
+        okBuilder.interceptors().add(freeSoundApiInterceptor);
 
         return okBuilder.build();
+    }
+
+    @Provides
+    @Singleton
+    static FreeSoundApiInterceptor provideApiInterceptor(@Named(API_TOKEN_CONFIG) String apiToken) {
+        return new FreeSoundApiInterceptor(apiToken);
     }
 
     @Qualifier

--- a/app/src/release/java/com/futurice/freesound/app/module/InstrumentationModule.java
+++ b/app/src/release/java/com/futurice/freesound/app/module/InstrumentationModule.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Futurice GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.futurice.freesound.app.module;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+import okhttp3.Interceptor;
+
+@Module
+public final class InstrumentationModule {
+
+    @Provides
+    @Singleton
+    @ApiModule.NetworkInterceptors
+    static List<Interceptor> provideNetworkInterceptors() {
+        return Collections.emptyList();
+    }
+
+    @Provides
+    @Singleton
+    @ApiModule.AppInterceptors
+    static List<Interceptor> provideAppInterceptors() {
+        return Collections.emptyList();
+    }
+}

--- a/app/src/testRelease/java/com/futurice/freesound/app/module/InstrumentationModuleTest.java
+++ b/app/src/testRelease/java/com/futurice/freesound/app/module/InstrumentationModuleTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Futurice GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.futurice.freesound.app.module;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentationModuleTest {
+    @Test
+    public void provideNetworkInterceptors_isEmpty_inReleaseVariant() {
+        assertThat(InstrumentationModule.provideNetworkInterceptors())
+                .isEmpty();
+    }
+
+    @Test
+    public void provideAppInterceptors_isEmpty_inReleaseVariant() {
+        assertThat(InstrumentationModule.provideAppInterceptors())
+                .isEmpty();
+    }
+}


### PR DESCRIPTION
Separate the InstrumentationModule between "debug" and "release" builds and install the Stetho interceptor only in the debug build.

This fixes the issue https://github.com/futurice/freesound-android/issues/22

I am not completely happy by this approach that in the end makes use of copy-pasting the class between different flavours. On the other hand, it is a quite clean solution and affects only the leaf provider. But if you have a more elegant solution (with Dagger 2) in mind, please let me know, as I am keen to learn. 

**Please note:** This PR depends on https://github.com/futurice/freesound-android/pull/57 and that's why this PR also contains the commit from the PR, but https://github.com/futurice/freesound-android/pull/57 should go in first. 