### PR TITLE
Don't end stream on search failure

### DIFF
--- a/app/src/main/java/com/futurice/freesound/feature/search/DefaultSearchDataModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/DefaultSearchDataModel.java
@@ -79,7 +79,8 @@ final class DefaultSearchDataModel implements SearchDataModel {
     }
 
     @NonNull
-    private static Option<List<Sound>> toResults(final SoundSearchResult soundSearchResult) {
+    private static Option<List<Sound>> toResults(
+            @NonNull final SoundSearchResult soundSearchResult) {
         return Option.ofObj(soundSearchResult.results());
     }
 

--- a/app/src/main/java/com/futurice/freesound/feature/search/DefaultSearchDataModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/DefaultSearchDataModel.java
@@ -75,7 +75,7 @@ final class DefaultSearchDataModel implements SearchDataModel {
     @Override
     @NonNull
     public Completable clear() {
-        return Completable.fromAction(onClear());
+        return Completable.fromAction(clearResultAndError());
     }
 
     @NonNull
@@ -95,7 +95,7 @@ final class DefaultSearchDataModel implements SearchDataModel {
     }
 
     @NonNull
-    private Action onClear() {
+    private Action clearResultAndError() {
         return () -> {
             lastResultsStream.onNext(Option.none());
             lastErrorStream.onNext(Option.none());

--- a/app/src/main/java/com/futurice/freesound/feature/search/DefaultSearchDataModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/DefaultSearchDataModel.java
@@ -79,7 +79,7 @@ final class DefaultSearchDataModel implements SearchDataModel {
     }
 
     @NonNull
-    private Consumer<Throwable> storeError(final @NonNull String query) {
+    private Consumer<Throwable> storeError(@NonNull final String query) {
         return e -> {
             lastErrorStream.onNext(Option.ofObj(e));
             e(e, "Error searching Freesound for query: %s ", query);

--- a/app/src/main/java/com/futurice/freesound/feature/search/DefaultSearchDataModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/DefaultSearchDataModel.java
@@ -40,10 +40,12 @@ final class DefaultSearchDataModel implements SearchDataModel {
     private final FreeSoundSearchService freeSoundSearchService;
 
     @NonNull
-    private final BehaviorSubject<Option<List<Sound>>> lastResultsStream = BehaviorSubject.create();
+    private final BehaviorSubject<Option<List<Sound>>> lastResultsOnceAndStream =
+            BehaviorSubject.createDefault(Option.none());
 
     @NonNull
-    private final BehaviorSubject<Option<Throwable>> lastErrorStream = BehaviorSubject.create();
+    private final BehaviorSubject<Option<Throwable>> lastErrorOnceAndStream =
+            BehaviorSubject.createDefault(Option.none());
 
     DefaultSearchDataModel(@NonNull final FreeSoundSearchService freeSoundSearchService) {
         this.freeSoundSearchService = get(freeSoundSearchService);
@@ -62,14 +64,14 @@ final class DefaultSearchDataModel implements SearchDataModel {
 
     @Override
     @NonNull
-    public Observable<Option<List<Sound>>> getSearchResultsStream() {
-        return lastResultsStream.hide();
+    public Observable<Option<List<Sound>>> getSearchResultsOnceAndStream() {
+        return lastResultsOnceAndStream.hide();
     }
 
     @Override
     @NonNull
-    public Observable<Option<Throwable>> getSearchErrorStream() {
-        return lastErrorStream.hide();
+    public Observable<Option<Throwable>> getSearchErrorOnceAndStream() {
+        return lastErrorOnceAndStream.hide();
     }
 
     @Override
@@ -81,7 +83,7 @@ final class DefaultSearchDataModel implements SearchDataModel {
     @NonNull
     private Consumer<Throwable> storeError(@NonNull final String query) {
         return e -> {
-            lastErrorStream.onNext(Option.ofObj(e));
+            lastErrorOnceAndStream.onNext(Option.ofObj(e));
             e(e, "Error searching Freesound for query: %s ", query);
         };
     }
@@ -89,16 +91,16 @@ final class DefaultSearchDataModel implements SearchDataModel {
     @NonNull
     private Consumer<Option<List<Sound>>> storeValueAndClearError() {
         return results -> {
-            lastResultsStream.onNext(results);
-            lastErrorStream.onNext(Option.none());
+            lastResultsOnceAndStream.onNext(results);
+            lastErrorOnceAndStream.onNext(Option.none());
         };
     }
 
     @NonNull
     private Action clearResultAndError() {
         return () -> {
-            lastResultsStream.onNext(Option.none());
-            lastErrorStream.onNext(Option.none());
+            lastResultsOnceAndStream.onNext(Option.none());
+            lastErrorOnceAndStream.onNext(Option.none());
         };
     }
 }

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchActivity.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchActivity.java
@@ -72,7 +72,7 @@ public class SearchActivity extends BindingBaseActivity<SearchActivityComponent>
             checkNotNull(searchViewModel, "View Model cannot be null.");
             checkNotNull(searchView, "Search view cannot be null.");
 
-            d.add(searchViewModel.isClearButtonVisibleOnceAndStream()
+            d.add(searchViewModel.isClearEnabledOnceAndStream()
                                  .observeOn(mainThread())
                                  .subscribe(SearchActivity.this::setClearSearchVisible,
                                             e -> e(e, "Error setting query string")));

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchActivityViewModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchActivityViewModel.java
@@ -79,7 +79,7 @@ final class SearchActivityViewModel extends BaseViewModel {
                                      .switchMap(query -> searchOrClear(query).toObservable())
                                      .subscribe(nothing1(),
                                                 e -> e(e,
-                                                       "Error when setting search term")));
+                                                       "Fatal error when setting search term")));
     }
 
     @NonNull

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchActivityViewModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchActivityViewModel.java
@@ -59,7 +59,7 @@ final class SearchActivityViewModel extends BaseViewModel {
     }
 
     @NonNull
-    Observable<Boolean> isClearButtonVisibleOnceAndStream() {
+    Observable<Boolean> isClearEnabledOnceAndStream() {
         return searchTermOnceAndStream.observeOn(Schedulers.computation())
                                       .map(SearchActivityViewModel::isCloseEnabled);
 

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchDataModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchDataModel.java
@@ -31,10 +31,10 @@ interface SearchDataModel {
     Completable querySearch(@NonNull String query);
 
     @NonNull
-    Observable<Option<List<Sound>>> getSearchResultsStream();
+    Observable<Option<List<Sound>>> getSearchResultsOnceAndStream();
 
     @NonNull
-    Observable<Option<Throwable>> getSearchErrorStream();
+    Observable<Option<Throwable>> getSearchErrorOnceAndStream();
 
     @NonNull
     Completable clear();

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchDataModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchDataModel.java
@@ -26,13 +26,15 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import polanski.option.Option;
 
-public interface SearchDataModel {
+interface SearchDataModel {
 
-    @NonNull
     Completable querySearch(@NonNull String query);
 
     @NonNull
     Observable<Option<List<Sound>>> getSearchResultsStream();
+
+    @NonNull
+    Observable<Option<Throwable>> getSearchErrorStream();
 
     @NonNull
     Completable clear();

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchFragment.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchFragment.java
@@ -74,7 +74,7 @@ public final class SearchFragment extends BindingBaseFragment<SearchFragmentComp
 
         @Override
         public void bind(@NonNull final CompositeDisposable disposables) {
-            disposables.add(viewModel().getSoundsStream()
+            disposables.add(viewModel().getSoundsOnceAndStream()
                                        .subscribeOn(Schedulers.computation())
                                        .observeOn(mainThread())
                                        .subscribe(SearchFragment.this::handleResults,

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchFragmentViewModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchFragmentViewModel.java
@@ -47,8 +47,8 @@ final class SearchFragmentViewModel extends BaseViewModel {
     }
 
     @NonNull
-    Observable<Option<List<DisplayableItem>>> getSoundsStream() {
-        return searchDataModel.getSearchResultsStream()
+    Observable<Option<List<DisplayableItem>>> getSoundsOnceAndStream() {
+        return searchDataModel.getSearchResultsOnceAndStream()
                               .map(it -> it.map(SearchFragmentViewModel::wrapInDisplayableItem));
     }
 

--- a/app/src/test/java/com/futurice/freesound/feature/search/DefaultSearchDataModelTest.java
+++ b/app/src/test/java/com/futurice/freesound/feature/search/DefaultSearchDataModelTest.java
@@ -166,6 +166,15 @@ public class DefaultSearchDataModelTest {
     }
 
     @Test
+    public void getSearchErrorStream_hasNoDefaultResults() {
+        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream()
+                                                                   .test();
+
+        ts.assertNoErrors()
+          .assertNoValues();
+    }
+
+    @Test
     public void getSearchErrorStream_isCleared_whenQuerySearchSuccessful() {
         new Arrangement().withSearchResultsFor(QUERY, dummyResults());
         TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream().test();
@@ -204,6 +213,28 @@ public class DefaultSearchDataModelTest {
         defaultSearchDataModel.querySearch(QUERY).subscribe();
 
         ts.assertNotTerminated();
+    }
+
+    @Test
+    public void clear_clearsSearchResults() {
+        TestObserver<Option<List<Sound>>> ts = defaultSearchDataModel.getSearchResultsStream()
+                                                                     .test();
+
+        defaultSearchDataModel.clear().subscribe();
+
+        ts.assertValue(Option.none())
+          .assertNotTerminated();
+    }
+
+    @Test
+    public void clear_clearsSearchErrors() {
+        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream()
+                                                                   .test();
+
+        defaultSearchDataModel.clear().subscribe();
+
+        ts.assertValue(Option.none())
+          .assertNotTerminated();
     }
 
     @Test

--- a/app/src/test/java/com/futurice/freesound/feature/search/DefaultSearchDataModelTest.java
+++ b/app/src/test/java/com/futurice/freesound/feature/search/DefaultSearchDataModelTest.java
@@ -125,11 +125,10 @@ public class DefaultSearchDataModelTest {
 
     @Test
     public void getSearchResults_hasNoDefaultResults() {
-        TestObserver<Option<List<Sound>>> ts = defaultSearchDataModel.getSearchResultsStream()
-                                                                     .test();
-
-        ts.assertNoErrors()
-          .assertNoValues();
+        defaultSearchDataModel.getSearchResultsStream()
+                              .test()
+                              .assertNotTerminated()
+                              .assertNoValues();
     }
 
     @Test
@@ -167,17 +166,17 @@ public class DefaultSearchDataModelTest {
 
     @Test
     public void getSearchErrorStream_hasNoDefaultResults() {
-        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream()
-                                                                   .test();
-
-        ts.assertNoErrors()
-          .assertNoValues();
+        defaultSearchDataModel.getSearchErrorStream()
+                              .test()
+                              .assertNotTerminated()
+                              .assertNoValues();
     }
 
     @Test
     public void getSearchErrorStream_isCleared_whenQuerySearchSuccessful() {
         new Arrangement().withSearchResultsFor(QUERY, dummyResults());
-        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream().test();
+        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream()
+                                                                   .test();
 
         defaultSearchDataModel.querySearch(QUERY).subscribe();
 
@@ -187,7 +186,8 @@ public class DefaultSearchDataModelTest {
     @Test
     public void getSearchErrorStream_doesNotTerminate_whenQuerySearchSuccessful() {
         new Arrangement().withSearchResultsFor(QUERY, dummyResults());
-        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream().test();
+        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream()
+                                                                   .test();
 
         defaultSearchDataModel.querySearch(QUERY).subscribe();
 
@@ -198,7 +198,8 @@ public class DefaultSearchDataModelTest {
     public void getSearchErrorStream_emitsErrorValue_whenQuerySearchErrors() {
         Exception searchError = new Exception();
         new Arrangement().withSearchResultError(searchError);
-        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream().test();
+        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream()
+                                                                   .test();
 
         defaultSearchDataModel.querySearch(QUERY).subscribe();
 
@@ -208,7 +209,8 @@ public class DefaultSearchDataModelTest {
     @Test
     public void getSearchErrorStream_doesNotTerminate_whenQuerySearchErrors() {
         new Arrangement().withSearchResultError(new Exception());
-        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream().test();
+        TestObserver<Option<Throwable>> ts = defaultSearchDataModel.getSearchErrorStream()
+                                                                   .test();
 
         defaultSearchDataModel.querySearch(QUERY).subscribe();
 

--- a/app/src/test/java/com/futurice/freesound/feature/search/DefaultSearchDataModelTest.java
+++ b/app/src/test/java/com/futurice/freesound/feature/search/DefaultSearchDataModelTest.java
@@ -56,7 +56,7 @@ public class DefaultSearchDataModelTest {
     }
 
     @Test
-    public void querySearch_queriesFreesoundSearchSearch() {
+    public void querySearch_queriesFreesoundSearchService() {
         new Arrangement().withDummySearchResult();
 
         defaultSearchDataModel.querySearch(QUERY).test();

--- a/app/src/test/java/com/futurice/freesound/feature/search/SearchActivityViewModelTest.java
+++ b/app/src/test/java/com/futurice/freesound/feature/search/SearchActivityViewModelTest.java
@@ -17,13 +17,21 @@
 package com.futurice.freesound.feature.search;
 
 import com.futurice.freesound.feature.analytics.Analytics;
+import com.futurice.freesound.feature.common.DisplayableItem;
+import com.futurice.freesound.test.data.TestData;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.List;
+
+import io.reactivex.observers.TestObserver;
+import polanski.option.Option;
+
 import static org.mockito.Mockito.verify;
+import static polanski.option.Option.ofObj;
 
 public class SearchActivityViewModelTest {
 
@@ -47,5 +55,25 @@ public class SearchActivityViewModelTest {
 
         verify(analytics).log("SearchPressedEvent");
     }
+
+//    @Test
+//    public void search_recoversFromSearchErrors() {
+//         ArrangeBuilder
+//                arrangeBuilder = new SearchFragmentViewModelTest.ArrangeBuilder().withErrorWhenSearching();
+//        TestObserver<Option<List<DisplayableItem>>> ts = viewModel.getSoundsStream().test();
+//
+//        viewModel.search("query");
+//
+//        ts.assertNoValues();
+//
+//        arrangeBuilder
+//                .withSuccessfulSearchResultStream()
+//                .enqueueSearchResults(ofObj(TestData.sounds(10)));
+//
+//        viewModel.search("query");
+//
+//        ts.assertValueCount(1);
+//    }
+//
 
 }

--- a/app/src/test/java/com/futurice/freesound/feature/search/SearchFragmentViewModelTest.java
+++ b/app/src/test/java/com/futurice/freesound/feature/search/SearchFragmentViewModelTest.java
@@ -31,14 +31,11 @@ import android.support.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.reactivex.Completable;
-import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import polanski.option.Option;
 
 import static com.futurice.freesound.feature.common.DisplayableItem.Type.SOUND;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static polanski.option.Option.ofObj;
 

--- a/app/src/test/java/com/futurice/freesound/feature/search/SearchFragmentViewModelTest.java
+++ b/app/src/test/java/com/futurice/freesound/feature/search/SearchFragmentViewModelTest.java
@@ -24,7 +24,6 @@ import com.futurice.freesound.test.data.TestData;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import android.support.annotation.NonNull;
@@ -32,11 +31,15 @@ import android.support.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.reactivex.Completable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import polanski.option.Option;
 
 import static com.futurice.freesound.feature.common.DisplayableItem.Type.SOUND;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static polanski.option.Option.ofObj;
 
 public class SearchFragmentViewModelTest {
@@ -74,6 +77,7 @@ public class SearchFragmentViewModelTest {
         ts.assertValue(ofObj(expectedDisplayableItems(sounds)));
     }
 
+
     @NonNull
     private static List<DisplayableItem> expectedDisplayableItems(
             @NonNull final List<Sound> sounds) {
@@ -86,15 +90,26 @@ public class SearchFragmentViewModelTest {
 
     private class ArrangeBuilder {
 
-        private final BehaviorSubject<Option<List<Sound>>> searchResultsStream = BehaviorSubject
-                .create();
+        private final BehaviorSubject<Option<List<Sound>>> mockedSearchResultsStream
+                = BehaviorSubject.create();
 
         ArrangeBuilder() {
-            Mockito.when(searchDataModel.getSearchResultsStream()).thenReturn(searchResultsStream);
+            withSuccessfulSearchResultStream();
+        }
+
+        ArrangeBuilder withSuccessfulSearchResultStream() {
+            when(searchDataModel.getSearchResultsStream()).thenReturn(mockedSearchResultsStream);
+            return this;
         }
 
         ArrangeBuilder enqueueSearchResults(@NonNull final Option<List<Sound>> sounds) {
-            searchResultsStream.onNext(sounds);
+            mockedSearchResultsStream.onNext(sounds);
+            return this;
+        }
+
+        ArrangeBuilder withErrorWhenSearching() {
+            when(searchDataModel.querySearch(anyString())).thenReturn(
+                    Completable.error(new Exception()));
             return this;
         }
     }

--- a/app/src/test/java/com/futurice/freesound/feature/search/SearchFragmentViewModelTest.java
+++ b/app/src/test/java/com/futurice/freesound/feature/search/SearchFragmentViewModelTest.java
@@ -98,7 +98,8 @@ public class SearchFragmentViewModelTest {
         }
 
         ArrangeBuilder withSuccessfulSearchResultStream() {
-            when(searchDataModel.getSearchResultsStream()).thenReturn(mockedSearchResultsStream);
+            when(searchDataModel.getSearchResultsOnceAndStream())
+                    .thenReturn(mockedSearchResultsStream);
             return this;
         }
 


### PR DESCRIPTION
Resolves #77 

I've added a set of tests which are marked `@Ignore` because they depend on that ability to remove the asynchronous nature of the Schedulers used in the `ActivityViewModel`. I figured this was the best way for now of defining the required behaviors. We should remove the `@Ignore` after #83 
