### PR TITLE
Update Proguard for AutoValue

### DIFF
--- a/app/proguard-rules/autovalue-rules.pro
+++ b/app/proguard-rules/autovalue-rules.pro
@@ -1,2 +1,4 @@
 -dontwarn com.google.auto.**
 -dontwarn autovalue.shaded.com.**
+-dontwarn sun.misc.Unsafe
+-dontwarn javax.lang.model.element.Modifier

--- a/app/proguard-rules/okio-rules.pro
+++ b/app/proguard-rules/okio-rules.pro
@@ -1,5 +1,5 @@
 # Okio rules from https://github.com/krschultz/android-proguard-snippets/blob/master/libraries/proguard-square-okio.pro
--keep class sun.misc.Unsafe { *; }
+#-keep class sun.misc.Unsafe { *; }
 -dontwarn java.nio.file.*
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 -dontwarn okio.**


### PR DESCRIPTION
Master has a broken release build without these rules that account for changes in the autovalue implementation.