### PR TITLE
Be sensible with @Nullable

### DIFF
--- a/app/src/main/java/com/futurice/freesound/app/FreesoundApplication.java
+++ b/app/src/main/java/com/futurice/freesound/app/FreesoundApplication.java
@@ -22,18 +22,14 @@ import com.futurice.freesound.inject.app.BaseApplicationModule;
 import com.squareup.leakcanary.LeakCanary;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import javax.inject.Inject;
 
 import timber.log.Timber;
 
-import static com.futurice.freesound.common.utils.Preconditions.get;
-
 public class FreesoundApplication extends BaseApplication<FreesoundApplicationComponent> {
 
     @Inject
-    @Nullable
     Timber.Tree loggingTree;
 
     @Override
@@ -64,7 +60,7 @@ public class FreesoundApplication extends BaseApplication<FreesoundApplicationCo
 
     private void initLogging() {
         Timber.uprootAll();
-        Timber.plant(get(loggingTree));
+        Timber.plant(loggingTree);
     }
 
     private void initStetho() {

--- a/app/src/main/java/com/futurice/freesound/core/BaseActivity.java
+++ b/app/src/main/java/com/futurice/freesound/core/BaseActivity.java
@@ -31,8 +31,7 @@ import android.support.v7.app.AppCompatActivity;
  */
 public abstract class BaseActivity<T> extends AppCompatActivity implements Injector<T> {
 
-    @Nullable
-    protected T component;
+    private T component;
 
     @CallSuper
     @Override

--- a/app/src/main/java/com/futurice/freesound/core/BaseApplication.java
+++ b/app/src/main/java/com/futurice/freesound/core/BaseApplication.java
@@ -21,7 +21,6 @@ import com.futurice.freesound.inject.Injector;
 import android.app.Application;
 import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 /**
  * A base Application which provides a dependency injection mechanism.
@@ -30,8 +29,7 @@ import android.support.annotation.Nullable;
  */
 public abstract class BaseApplication<T> extends Application implements Injector<T> {
 
-    @Nullable
-    protected T component;
+    private T component;
 
     @CallSuper
     @Override

--- a/app/src/main/java/com/futurice/freesound/core/BaseFragment.java
+++ b/app/src/main/java/com/futurice/freesound/core/BaseFragment.java
@@ -31,8 +31,7 @@ import android.support.v4.app.Fragment;
  */
 public abstract class BaseFragment<T> extends Fragment implements Injector<T> {
 
-    @Nullable
-    protected T component;
+    private T component;
 
     @CallSuper
     @Override

--- a/app/src/main/java/com/futurice/freesound/feature/common/waveform/WaveformView.java
+++ b/app/src/main/java/com/futurice/freesound/feature/common/waveform/WaveformView.java
@@ -26,7 +26,6 @@ import android.graphics.Paint;
 import android.graphics.Rect;
 import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.View;
@@ -47,7 +46,6 @@ public class WaveformView extends View implements WaveformRender {
     private final int columnWidthPx; // waveform column
     private final int columnGapPx; // padding between columns
 
-    @Nullable
     private float[] waveform;
 
     public WaveformView(final Context context, AttributeSet attrs) {

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeActivity.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeActivity.java
@@ -26,7 +26,6 @@ import com.futurice.freesound.viewmodel.ViewModel;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -40,7 +39,6 @@ import static com.futurice.freesound.common.utils.Preconditions.get;
 public class HomeActivity extends BindingBaseActivity<HomeActivityComponent> {
 
     @Inject
-    @Nullable
     HomeViewModel homeViewModel;
 
     @NonNull
@@ -81,7 +79,7 @@ public class HomeActivity extends BindingBaseActivity<HomeActivityComponent> {
             case R.id.action_about:
                 return true;
             case R.id.action_search:
-                get(homeViewModel).openSearch();
+                homeViewModel.openSearch();
                 return true;
             default:
                 return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeFragment.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeFragment.java
@@ -46,29 +46,23 @@ import static com.futurice.freesound.common.utils.Preconditions.get;
 
 public final class HomeFragment extends BindingBaseFragment<HomeFragmentComponent> {
 
-    @Nullable
     @Inject
     HomeFragmentViewModel homeFragmentViewModel;
 
-    @Nullable
     @Inject
     Picasso picasso;
 
-    @Nullable
     @Inject
     SchedulerProvider schedulerProvider;
 
-    @Nullable
     @BindView(R.id.avatar_image)
     ImageView avatarImage;
 
-    @Nullable
     @BindView(R.id.username_textView)
-    TextView userName;
+    TextView userNameTextView;
 
-    @Nullable
     @BindView(R.id.about_textView)
-    TextView about;
+    TextView aboutTextView;
 
     @NonNull
     private final AtomicOption<Unbinder> unbinder = new AtomicOption<>();
@@ -83,26 +77,26 @@ public final class HomeFragment extends BindingBaseFragment<HomeFragmentComponen
             d.add(homeFragmentViewModel.getImage()
                                        .subscribeOn(schedulerProvider.computation())
                                        .observeOn(schedulerProvider.ui())
-                                       .subscribe(it -> get(picasso).load(it)
-                                                                    .into(avatarImage),
+                                       .subscribe(it -> picasso.load(it)
+                                                               .into(avatarImage),
                                                   e -> Timber.e(e, "Error setting image")));
 
             d.add(homeFragmentViewModel.getUserName()
                                        .subscribeOn(schedulerProvider.computation())
                                        .observeOn(schedulerProvider.ui())
-                                       .subscribe(it -> get(userName).setText(it),
+                                       .subscribe(it -> userNameTextView.setText(it),
                                                   e -> Timber.e(e, "Error setting user")));
 
             d.add(homeFragmentViewModel.getAbout()
                                        .subscribeOn(schedulerProvider.computation())
                                        .observeOn(schedulerProvider.ui())
-                                       .subscribe(it -> get(about).setText(it),
-                                                  e -> Timber.e(e, "Error setting about")));
+                                       .subscribe(it -> aboutTextView.setText(it),
+                                                  e -> Timber.e(e, "Error setting aboutTextView")));
         }
 
         @Override
         public void unbind() {
-            get(picasso).cancelRequest(avatarImage);
+            picasso.cancelRequest(avatarImage);
         }
 
     };

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchActivity.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchActivity.java
@@ -31,9 +31,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.design.widget.CoordinatorLayout;
-import android.support.v7.appcompat.R;
 import android.support.v7.widget.SearchView;
 import android.support.v7.widget.SearchView.OnQueryTextListener;
 import android.support.v7.widget.Toolbar;
@@ -57,26 +55,21 @@ import static timber.log.Timber.e;
 
 public class SearchActivity extends BindingBaseActivity<SearchActivityComponent> {
 
-    @Nullable
     @Inject
     SearchActivityViewModel searchViewModel;
 
-    @Nullable
     @Inject
     SearchSnackbar searchSnackbar;
 
-    @Nullable
     @Inject
     SchedulerProvider schedulerProvider;
 
-    @Nullable
     @BindView(id.search_view)
     SearchView searchView;
 
-    @Nullable
-    private ImageView closeButton;
+    @BindView(id.search_close_btn)
+    ImageView closeButton;
 
-    @Nullable
     @BindView(id.search_coordinatorlayout)
     CoordinatorLayout coordinatorLayout;
 
@@ -112,9 +105,7 @@ public class SearchActivity extends BindingBaseActivity<SearchActivityComponent>
     }
 
     private void setClearSearchVisible(final boolean clearVisible) {
-        checkNotNull(closeButton, "Close Button has not been bound");
-
-        get(closeButton).setVisibility(clearVisible ? View.VISIBLE : View.GONE);
+        closeButton.setVisibility(clearVisible ? View.VISIBLE : View.GONE);
     }
 
     public static void open(@NonNull final Context context) {
@@ -136,8 +127,7 @@ public class SearchActivity extends BindingBaseActivity<SearchActivityComponent>
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        get(searchView).setIconified(false);
-        closeButton = findById(searchView, R.id.search_close_btn);
+        searchView.setIconified(false);
 
         searchView.setOnCloseListener(() -> {
             searchView.setQuery(SearchActivityViewModel.NO_SEARCH, true);
@@ -211,10 +201,10 @@ public class SearchActivity extends BindingBaseActivity<SearchActivityComponent>
 
     private void showSnackbar(@NonNull final CharSequence charSequence) {
         checkNotNull(charSequence);
-        get(searchSnackbar).showNewSnackbar(get(coordinatorLayout), charSequence);
+        searchSnackbar.showNewSnackbar(coordinatorLayout, charSequence);
     }
 
     private void dismissSnackbar() {
-        get(searchSnackbar).dismissSnackbar();
+        searchSnackbar.dismissSnackbar();
     }
 }

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchFragment.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchFragment.java
@@ -45,27 +45,21 @@ import polanski.option.Option;
 import timber.log.Timber;
 
 import static butterknife.ButterKnife.bind;
-import static com.futurice.freesound.common.utils.Preconditions.get;
 
 public final class SearchFragment extends BindingBaseFragment<SearchFragmentComponent> {
 
-    @Nullable
     @Inject
     SearchFragmentViewModel searchFragmentViewModel;
 
-    @Nullable
     @Inject
     SoundItemAdapter soundItemAdapter;
 
-    @Nullable
     @Inject
     SchedulerProvider schedulerProvider;
 
-    @Nullable
     @BindView(R.id.recyclerView_searchResults)
     RecyclerView resultsRecyclerView;
 
-    @Nullable
     @BindView(R.id.textView_searchNoResults)
     TextView noResultsTextView;
 
@@ -78,7 +72,7 @@ public final class SearchFragment extends BindingBaseFragment<SearchFragmentComp
         @Override
         public void bind(@NonNull final CompositeDisposable disposables) {
             disposables.add(viewModel().getSoundsOnceAndStream()
-                                       .subscribeOn(get(schedulerProvider).computation())
+                                       .subscribeOn(schedulerProvider.computation())
                                        .observeOn(schedulerProvider.ui())
                                        .subscribe(SearchFragment.this::handleResults,
                                                   e -> Timber.e(e, "Error setting Sound items")));
@@ -107,7 +101,7 @@ public final class SearchFragment extends BindingBaseFragment<SearchFragmentComp
         unbinder.setIfNone(bind(this, view));
         final LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
         layoutManager.setRecycleChildrenOnDetach(true);
-        get(resultsRecyclerView).setLayoutManager(layoutManager);
+        resultsRecyclerView.setLayoutManager(layoutManager);
     }
 
     @Override
@@ -120,7 +114,7 @@ public final class SearchFragment extends BindingBaseFragment<SearchFragmentComp
     @Override
     public void onActivityCreated(@Nullable final Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        get(resultsRecyclerView).setAdapter(get(soundItemAdapter));
+        resultsRecyclerView.setAdapter(soundItemAdapter);
     }
 
     @Override
@@ -141,7 +135,7 @@ public final class SearchFragment extends BindingBaseFragment<SearchFragmentComp
     @NonNull
     @Override
     protected SearchFragmentViewModel viewModel() {
-        return get(searchFragmentViewModel);
+        return searchFragmentViewModel;
     }
 
     @NonNull
@@ -155,18 +149,18 @@ public final class SearchFragment extends BindingBaseFragment<SearchFragmentComp
     }
 
     private void showNothing() {
-        get(noResultsTextView).setVisibility(View.GONE);
-        get(resultsRecyclerView).setVisibility(View.GONE);
+        noResultsTextView.setVisibility(View.GONE);
+        resultsRecyclerView.setVisibility(View.GONE);
     }
 
     private void showResults(@NonNull final List<DisplayableItem> sounds) {
-        if (get(sounds).isEmpty()) {
-            get(noResultsTextView).setVisibility(View.VISIBLE);
-            get(resultsRecyclerView).setVisibility(View.GONE);
+        if (sounds.isEmpty()) {
+            noResultsTextView.setVisibility(View.VISIBLE);
+            resultsRecyclerView.setVisibility(View.GONE);
         } else {
-            get(noResultsTextView).setVisibility(View.GONE);
-            get(resultsRecyclerView).setVisibility(View.VISIBLE);
-            get(soundItemAdapter).setItems(get(sounds));
+            noResultsTextView.setVisibility(View.GONE);
+            resultsRecyclerView.setVisibility(View.VISIBLE);
+            soundItemAdapter.setItems(sounds);
         }
     }
 

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchSnackbar.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchSnackbar.java
@@ -1,7 +1,6 @@
 package com.futurice.freesound.feature.search;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.view.View;
 
@@ -14,7 +13,6 @@ import static com.futurice.freesound.common.utils.Preconditions.checkNotNull;
  */
 class SearchSnackbar {
 
-    @Nullable
     private Snackbar snackbar;
 
     /**

--- a/app/src/main/java/com/futurice/freesound/viewmodel/viewholder/BaseBindingViewHolder.java
+++ b/app/src/main/java/com/futurice/freesound/viewmodel/viewholder/BaseBindingViewHolder.java
@@ -20,7 +20,6 @@ import com.futurice.freesound.viewmodel.DataBinder;
 import com.futurice.freesound.viewmodel.ViewModel;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.View;
 
 import io.reactivex.disposables.CompositeDisposable;
@@ -36,7 +35,6 @@ import static com.futurice.freesound.common.utils.Preconditions.get;
 public abstract class BaseBindingViewHolder<T extends ViewModel>
         extends AbstractBindingViewHolder<T> {
 
-    @Nullable
     private T viewModel;
 
     @NonNull
@@ -61,9 +59,8 @@ public abstract class BaseBindingViewHolder<T extends ViewModel>
     @NonNull
     protected abstract DataBinder getViewDataBinder();
 
-    @Nullable
     protected final T getViewModel() {
-        return viewModel;
+        return get(viewModel);
     }
 
     private void bindViewToViewModel() {

--- a/app/src/test/java/com/futurice/freesound/feature/home/HomeFragmentViewModelTest.java
+++ b/app/src/test/java/com/futurice/freesound/feature/home/HomeFragmentViewModelTest.java
@@ -99,7 +99,7 @@ public class HomeFragmentViewModelTest {
         return new UserBuilder()
                 .largeAvatar("large.com")
                 .userName("user name")
-                .about("about")
+                .about("aboutTextView")
                 .build();
     }
 


### PR DESCRIPTION
Our use of `@Nullable` is somewhat pathological. Let's try to boil it down to some specific criteria:

1. Optional values
2. Enforcing of nullability to satisfy an external API: e.g. check for null before exposing a technically nullable value as non-null.

Let's not:
1. Use `@Nullable` when something is technically nullable because its initialization is delayed due to the lifecycle.
