### PR TITLE
Use Dagger subcomponents

### DIFF
--- a/app/src/main/java/com/futurice/freesound/app/FreesoundApplicationComponent.java
+++ b/app/src/main/java/com/futurice/freesound/app/FreesoundApplicationComponent.java
@@ -19,6 +19,7 @@ package com.futurice.freesound.app;
 import com.futurice.freesound.feature.analytics.Analytics;
 import com.futurice.freesound.feature.common.scheduling.SchedulerProvider;
 import com.futurice.freesound.feature.home.HomeActivityComponent;
+import com.futurice.freesound.feature.search.SearchActivityComponent;
 import com.futurice.freesound.inject.activity.BaseActivityModule;
 import com.futurice.freesound.inject.app.BaseApplicationComponent;
 import com.futurice.freesound.inject.app.ForApplication;
@@ -50,6 +51,8 @@ public interface FreesoundApplicationComponent extends BaseApplicationComponent 
 
     void inject(final FreesoundApplication application);
 
-    HomeActivityComponent plus(BaseActivityModule baseActivityModule);
+    HomeActivityComponent plusHomeActivityComponent(BaseActivityModule baseActivityModule);
+
+    SearchActivityComponent plusSearchActivityComponent(BaseActivityModule baseActivityModule);
 
 }

--- a/app/src/main/java/com/futurice/freesound/app/FreesoundApplicationComponent.java
+++ b/app/src/main/java/com/futurice/freesound/app/FreesoundApplicationComponent.java
@@ -18,6 +18,8 @@ package com.futurice.freesound.app;
 
 import com.futurice.freesound.feature.analytics.Analytics;
 import com.futurice.freesound.feature.common.scheduling.SchedulerProvider;
+import com.futurice.freesound.feature.home.HomeActivityComponent;
+import com.futurice.freesound.inject.activity.BaseActivityModule;
 import com.futurice.freesound.inject.app.BaseApplicationComponent;
 import com.futurice.freesound.inject.app.ForApplication;
 import com.futurice.freesound.network.api.FreeSoundApiService;
@@ -47,4 +49,7 @@ public interface FreesoundApplicationComponent extends BaseApplicationComponent 
     SchedulerProvider getSchedulerProvider();
 
     void inject(final FreesoundApplication application);
+
+    HomeActivityComponent plus(BaseActivityModule baseActivityModule);
+
 }

--- a/app/src/main/java/com/futurice/freesound/feature/audio/AudioModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/audio/AudioModule.java
@@ -39,21 +39,25 @@ import com.futurice.freesound.inject.app.ForApplication;
 import android.content.Context;
 import android.net.Uri;
 
-import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import io.reactivex.Observable;
 
 @Module
-public abstract class AudioModule {
+public class AudioModule {
+
+    /**
+     * Can't use @Binds because of this: https://github.com/google/dagger/issues/348
+     */
 
     /*
      * Current app visual design means that instances are not shared between Activities.
      */
-
-    @Binds
+    @Provides
     @ActivityScope
-    abstract AudioPlayer provideAudioPlayer(ExoPlayerAudioPlayer exoPlayerAudioPlayer);
+    AudioPlayer provideAudioPlayer(ExoPlayerAudioPlayer exoPlayerAudioPlayer) {
+        return exoPlayerAudioPlayer;
+    }
 
     //
     // Internal
@@ -68,20 +72,28 @@ public abstract class AudioModule {
                                                null, null);
     }
 
-    @Binds
-    abstract Observable<ExoPlayerState> provideExoPlayerStateObservable(
-            ExoPlayerStateObservable observable);
+    @Provides
+    Observable<ExoPlayerState> provideExoPlayerStateObservable(
+            ExoPlayerStateObservable observable) {
+        return observable;
+    }
 
-    @Binds
-    abstract Observable<Long> provideExoPlayerProgressObservable(
-            ExoPlayerProgressObservable observable);
+    @Provides
+    Observable<Long> provideExoPlayerProgressObservable(
+            ExoPlayerProgressObservable observable) {
+        return observable;
+    }
 
-    @Binds
+    @Provides
     @ActivityScope
-    abstract ExoPlayer provideExoPlayer(SimpleExoPlayer simpleExoPlayer);
+    ExoPlayer provideExoPlayer(SimpleExoPlayer simpleExoPlayer) {
+        return simpleExoPlayer;
+    }
 
-    @Binds
-    abstract ObservableExoPlayer provideObservableExoPlayer(DefaultObservableExoPlayer exoPlayer);
+    @Provides
+    ObservableExoPlayer provideObservableExoPlayer(DefaultObservableExoPlayer exoPlayer) {
+        return exoPlayer;
+    }
 
     @Provides
     static DataSource.Factory provideDataSourceFactory(@ForApplication Context context) {

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeActivity.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeActivity.java
@@ -90,7 +90,8 @@ public class HomeActivity extends BindingBaseActivity<HomeActivityComponent> {
     @Override
     protected HomeActivityComponent createComponent() {
         return ((FreesoundApplication) getApplication()).component()
-                                                        .plus(new BaseActivityModule(this));
+                                                        .plusHomeActivityComponent(
+                                                                new BaseActivityModule(this));
     }
 
     @Override

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeActivity.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeActivity.java
@@ -89,12 +89,8 @@ public class HomeActivity extends BindingBaseActivity<HomeActivityComponent> {
     @NonNull
     @Override
     protected HomeActivityComponent createComponent() {
-        return DaggerHomeActivityComponent.builder()
-                                          .freesoundApplicationComponent(
-                                                  ((FreesoundApplication) getApplication())
-                                                          .component())
-                                          .baseActivityModule(new BaseActivityModule(this))
-                                          .build();
+        return ((FreesoundApplication) getApplication()).component()
+                                                        .plus(new BaseActivityModule(this));
     }
 
     @Override

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeActivityComponent.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeActivityComponent.java
@@ -16,18 +16,15 @@
 
 package com.futurice.freesound.feature.home;
 
-import com.futurice.freesound.app.FreesoundApplicationComponent;
 import com.futurice.freesound.feature.common.Navigator;
-import com.futurice.freesound.feature.common.scheduling.SchedulerProvider;
 import com.futurice.freesound.inject.activity.ActivityScope;
 import com.futurice.freesound.inject.activity.BaseActivityComponent;
-import com.squareup.picasso.Picasso;
+import com.futurice.freesound.inject.fragment.BaseFragmentModule;
 
-import dagger.Component;
+import dagger.Subcomponent;
 
 @ActivityScope
-@Component(dependencies = FreesoundApplicationComponent.class,
-        modules = HomeActivityModule.class)
+@Subcomponent(modules = HomeActivityModule.class)
 public interface HomeActivityComponent extends BaseActivityComponent {
 
     HomeViewModel getHomeViewModel();
@@ -36,11 +33,9 @@ public interface HomeActivityComponent extends BaseActivityComponent {
 
     UserDataModel getUserDataModel();
 
-    Picasso getPicasso();
-
-    SchedulerProvider getSchedulerProvider();
-
     void inject(final HomeActivity activity);
+
+    HomeFragmentComponent plus(BaseFragmentModule baseFragmentModule);
 }
 
 

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeActivityComponent.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeActivityComponent.java
@@ -27,8 +27,6 @@ import dagger.Subcomponent;
 @Subcomponent(modules = HomeActivityModule.class)
 public interface HomeActivityComponent extends BaseActivityComponent {
 
-    HomeViewModel getHomeViewModel();
-
     Navigator getNavigator();
 
     UserDataModel getUserDataModel();

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeActivityModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeActivityModule.java
@@ -26,7 +26,7 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module(includes = BaseActivityModule.class)
-class HomeActivityModule {
+public class HomeActivityModule {
 
     @Provides
     @ActivityScope

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeActivityModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeActivityModule.java
@@ -16,6 +16,7 @@
 
 package com.futurice.freesound.feature.home;
 
+import com.futurice.freesound.common.InstantiationForbiddenError;
 import com.futurice.freesound.feature.common.Navigator;
 import com.futurice.freesound.feature.common.scheduling.SchedulerProvider;
 import com.futurice.freesound.inject.activity.ActivityScope;
@@ -26,7 +27,7 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module(includes = BaseActivityModule.class)
-public class HomeActivityModule {
+class HomeActivityModule {
 
     @Provides
     @ActivityScope
@@ -39,6 +40,10 @@ public class HomeActivityModule {
     @ActivityScope
     static UserDataModel provideUserDataModel(FreeSoundApiService freeSoundApiService) {
         return new DefaultUserDataModel(freeSoundApiService);
+    }
+
+    private HomeActivityModule() {
+        throw new InstantiationForbiddenError();
     }
 
 }

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeFragment.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeFragment.java
@@ -79,7 +79,8 @@ public final class HomeFragment extends BindingBaseFragment<HomeFragmentComponen
                                        .subscribeOn(schedulerProvider.computation())
                                        .observeOn(schedulerProvider.ui())
                                        .subscribe(it -> picasso.load(it)
-                                                               .transform(PicassoTransformations.circular())
+                                                               .transform(PicassoTransformations
+                                                                                  .circular())
                                                                .into(avatarImage),
                                                   e -> Timber.e(e, "Error setting image")));
 
@@ -135,11 +136,8 @@ public final class HomeFragment extends BindingBaseFragment<HomeFragmentComponen
     @NonNull
     @Override
     protected HomeFragmentComponent createComponent() {
-        return DaggerHomeFragmentComponent.builder()
-                                          .homeActivityComponent(
-                                                  ((HomeActivity) getActivity()).component())
-                                          .baseFragmentModule(new BaseFragmentModule(this))
-                                          .build();
+        return ((HomeActivity) getActivity())
+                .component().plus(new BaseFragmentModule(this));
     }
 
     @NonNull

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeFragmentComponent.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeFragmentComponent.java
@@ -19,12 +19,13 @@ package com.futurice.freesound.feature.home;
 import com.futurice.freesound.inject.fragment.BaseFragmentComponent;
 import com.futurice.freesound.inject.fragment.FragmentScope;
 
-import dagger.Component;
+import dagger.Subcomponent;
 
 @FragmentScope
-@Component(dependencies = HomeActivityComponent.class, modules = HomeFragmentModule.class)
-interface HomeFragmentComponent extends BaseFragmentComponent {
+@Subcomponent(modules = HomeFragmentModule.class)
+public interface HomeFragmentComponent extends BaseFragmentComponent {
 
     void inject(final HomeFragment homeFragment);
+
 }
 

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeFragmentModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeFragmentModule.java
@@ -16,6 +16,7 @@
 
 package com.futurice.freesound.feature.home;
 
+import com.futurice.freesound.common.InstantiationForbiddenError;
 import com.futurice.freesound.inject.fragment.BaseFragmentModule;
 import com.futurice.freesound.inject.fragment.FragmentScope;
 
@@ -23,12 +24,16 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module(includes = BaseFragmentModule.class)
-public class HomeFragmentModule {
+class HomeFragmentModule {
 
     @Provides
     @FragmentScope
     static HomeFragmentViewModel provideHomeFragmentViewModel(UserDataModel userDataModel) {
         return new HomeFragmentViewModel(userDataModel);
+    }
+
+    private HomeFragmentModule() {
+        throw new InstantiationForbiddenError();
     }
 
 }

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeFragmentModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeFragmentModule.java
@@ -23,7 +23,7 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module(includes = BaseFragmentModule.class)
-class HomeFragmentModule {
+public class HomeFragmentModule {
 
     @Provides
     @FragmentScope

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeViewModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeViewModel.java
@@ -29,7 +29,7 @@ import timber.log.Timber;
 
 import static com.futurice.freesound.common.utils.Preconditions.get;
 
-final class HomeViewModel extends SimpleViewModel {
+public final class HomeViewModel extends SimpleViewModel {
 
     @NonNull
     private final Navigator navigator;

--- a/app/src/main/java/com/futurice/freesound/feature/home/HomeViewModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/HomeViewModel.java
@@ -29,7 +29,7 @@ import timber.log.Timber;
 
 import static com.futurice.freesound.common.utils.Preconditions.get;
 
-public final class HomeViewModel extends SimpleViewModel {
+final class HomeViewModel extends SimpleViewModel {
 
     @NonNull
     private final Navigator navigator;

--- a/app/src/main/java/com/futurice/freesound/feature/home/UserDataModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/home/UserDataModel.java
@@ -22,7 +22,7 @@ import android.support.annotation.NonNull;
 
 import io.reactivex.Single;
 
-interface UserDataModel {
+public interface UserDataModel {
 
     @NonNull
     Single<User> getHomeUser();

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchActivity.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchActivity.java
@@ -102,6 +102,23 @@ public class SearchActivity extends BindingBaseActivity<SearchActivityComponent>
                                  .subscribe(SearchActivity.this::handleErrorState,
                                             e -> e(e, "Error receiving Errors")));
         }
+
+        private void subscribeToSearchView(@NonNull final SearchView view,
+                                           @NonNull final ObservableEmitter<String> emitter) {
+            view.setOnQueryTextListener(new OnQueryTextListener() {
+                @Override
+                public boolean onQueryTextSubmit(final String query) {
+                    return false;
+                }
+
+                @Override
+                public boolean onQueryTextChange(final String newText) {
+                    emitter.onNext(get(newText));
+                    return true;
+                }
+            });
+        }
+
     };
 
     public static void open(@NonNull final Context context) {
@@ -152,12 +169,8 @@ public class SearchActivity extends BindingBaseActivity<SearchActivityComponent>
     @NonNull
     @Override
     protected SearchActivityComponent createComponent() {
-        return DaggerSearchActivityComponent.builder()
-                                            .freesoundApplicationComponent(
-                                                    ((FreesoundApplication) getApplication())
-                                                            .component())
-                                            .baseActivityModule(new BaseActivityModule(this))
-                                            .build();
+        return ((FreesoundApplication) getApplication())
+                .component().plusSearchActivityComponent(new BaseActivityModule(this));
     }
 
     @Override
@@ -180,22 +193,6 @@ public class SearchActivity extends BindingBaseActivity<SearchActivityComponent>
 
     private void setClearSearchVisible(final boolean isClearButtonVisible) {
         closeButton.setVisibility(isClearButtonVisible ? View.VISIBLE : View.GONE);
-    }
-
-    private static void subscribeToSearchView(@NonNull final SearchView view,
-                                              @NonNull final ObservableEmitter<String> emitter) {
-        view.setOnQueryTextListener(new OnQueryTextListener() {
-            @Override
-            public boolean onQueryTextSubmit(final String query) {
-                return false;
-            }
-
-            @Override
-            public boolean onQueryTextChange(final String newText) {
-                emitter.onNext(get(newText));
-                return true;
-            }
-        });
     }
 
     private void showSnackbar(@NonNull final CharSequence charSequence) {

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchActivityComponent.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchActivityComponent.java
@@ -16,40 +16,25 @@
 
 package com.futurice.freesound.feature.search;
 
-import com.futurice.freesound.app.FreesoundApplicationComponent;
 import com.futurice.freesound.feature.audio.AudioPlayer;
 import com.futurice.freesound.feature.common.Navigator;
-import com.futurice.freesound.feature.common.scheduling.SchedulerProvider;
 import com.futurice.freesound.inject.activity.ActivityScope;
 import com.futurice.freesound.inject.activity.BaseActivityComponent;
-import com.futurice.freesound.inject.app.ForApplication;
-import com.futurice.freesound.network.api.FreeSoundApiService;
-import com.squareup.picasso.Picasso;
+import com.futurice.freesound.inject.fragment.BaseFragmentModule;
 
-import android.content.Context;
-
-import dagger.Component;
+import dagger.Subcomponent;
 
 @ActivityScope
-@Component(dependencies = FreesoundApplicationComponent.class, modules = SearchActivityModule.class)
-interface SearchActivityComponent extends BaseActivityComponent {
-
-    @ForApplication
-    Context getContext();
+@Subcomponent(modules = SearchActivityModule.class)
+public interface SearchActivityComponent extends BaseActivityComponent {
 
     SearchDataModel getSearchDataModel();
 
     Navigator getNavigator();
 
-    Picasso getPicasso();
-
     AudioPlayer getAudioPlayer();
 
-    FreeSoundApiService getFreeSoundApiService();
-
-    SchedulerProvider getSchedulerProvider();
-
     void inject(final SearchActivity activity);
+
+    SearchFragmentComponent plusSearchFragmentComponent(BaseFragmentModule baseFragmentModule);
 }
-
-

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchActivityModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchActivityModule.java
@@ -16,6 +16,7 @@
 
 package com.futurice.freesound.feature.search;
 
+import com.futurice.freesound.common.InstantiationForbiddenError;
 import com.futurice.freesound.feature.analytics.Analytics;
 import com.futurice.freesound.feature.audio.AudioModule;
 import com.futurice.freesound.feature.audio.AudioPlayer;
@@ -28,7 +29,7 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module(includes = {BaseActivityModule.class, AudioModule.class})
-class SearchActivityModule {
+public class SearchActivityModule {
 
     @Provides
     @ActivityScope
@@ -53,6 +54,10 @@ class SearchActivityModule {
     @ActivityScope
     static SearchSnackbar provideSearchSnackbar() {
         return new SearchSnackbar();
+    }
+
+    private SearchActivityModule() {
+        throw new InstantiationForbiddenError();
     }
 
 }

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchDataModel.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchDataModel.java
@@ -21,7 +21,7 @@ import android.support.annotation.NonNull;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 
-interface SearchDataModel {
+public interface SearchDataModel {
 
     @NonNull
     Completable querySearch(@NonNull String query, @NonNull final Completable preliminaryTask);

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchFragment.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchFragment.java
@@ -136,11 +136,9 @@ public final class SearchFragment extends BindingBaseFragment<SearchFragmentComp
     @NonNull
     @Override
     protected SearchFragmentComponent createComponent() {
-        return DaggerSearchFragmentComponent.builder()
-                                            .searchActivityComponent(
-                                                    ((SearchActivity) getActivity()).component())
-                                            .baseFragmentModule(new BaseFragmentModule(this))
-                                            .build();
+        return ((SearchActivity) getActivity()).component()
+                                               .plusSearchFragmentComponent(
+                                                       new BaseFragmentModule(this));
     }
 
     @NonNull

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchFragmentComponent.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchFragmentComponent.java
@@ -19,11 +19,11 @@ package com.futurice.freesound.feature.search;
 import com.futurice.freesound.inject.fragment.BaseFragmentComponent;
 import com.futurice.freesound.inject.fragment.FragmentScope;
 
-import dagger.Component;
+import dagger.Subcomponent;
 
 @FragmentScope
-@Component(dependencies = SearchActivityComponent.class, modules = SearchFragmentModule.class)
-interface SearchFragmentComponent extends BaseFragmentComponent {
+@Subcomponent(modules = SearchFragmentModule.class)
+public interface SearchFragmentComponent extends BaseFragmentComponent {
 
     void inject(final SearchFragment searchFragment);
 }

--- a/app/src/main/java/com/futurice/freesound/feature/search/SearchFragmentModule.java
+++ b/app/src/main/java/com/futurice/freesound/feature/search/SearchFragmentModule.java
@@ -40,7 +40,7 @@ import dagger.multibindings.IntoMap;
 import static com.futurice.freesound.feature.search.SearchConstants.SearchResultListItems.SOUND;
 
 @Module(includes = BaseFragmentModule.class)
-class SearchFragmentModule {
+public class SearchFragmentModule {
 
     @Provides
     @FragmentScope


### PR DESCRIPTION
Use Dagger subcomponents to reduce the boilerplate when Fragments requires singleton dependencies.