### PR TITLE
Remove Travis workaround for android 25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ android:
     components:
         - platform-tools
         - tools
-        - tools
         - build-tools-25.0.2
         - android-25
         - android-24


### PR DESCRIPTION
A few months ago it was needed to duplicate `-tools` as a workaround to run Travis on android 25. Now the issue has been fixed.