### PR TITLE
Use google() repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ android:
         - android-25
         - android-24
         - extra-google-m2repository
-        - extra-android-m2repository
         - sys-img-armeabi-v7a-android-24
 
 before_install:

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     ext.kotlin_version = '1.1.3'
     repositories {
         jcenter()
+        google()
         maven { url "https://maven.google.com" }
         maven { url "https://plugins.gradle.org/m2/" }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     repositories {
         jcenter()
         google()
-        maven { url "https://maven.google.com" }
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {


### PR DESCRIPTION
`extra-google-m2repository` is still required for Firebase.